### PR TITLE
Improve cleanTitle spacing

### DIFF
--- a/nombra.go
+++ b/nombra.go
@@ -388,20 +388,21 @@ func truncateContent(content string) string {
 // cleanTitle cleans and formats the generated title by removing extraneous quotes and whitespace,
 // normalizing spacing around dashes, and ensuring proper text formatting.
 func cleanTitle(title string) string {
-	// Remove extraneous quotes and whitespace
-	title = strings.Trim(title, "\"'\"'' \t\n")
+	// Remove extraneous quotes and surrounding whitespace
+	title = strings.Trim(title, "\"' \t\n")
 
 	// Replace newlines with a single space
 	title = strings.ReplaceAll(title, "\n", " ")
 
-	// Ensure that dashes have a single space on each side
-	title = regexp.MustCompile(`\s*-\s*`).ReplaceAllString(title, " - ")
-
-	// Optionally, insert spaces between a lowercase letter followed immediately by an uppercase letter
+	// Insert spaces between a lowercase letter followed immediately by an uppercase letter
 	title = regexp.MustCompile(`([a-z])([A-Z])`).ReplaceAllString(title, "$1 $2")
 
-	// Collapse any extra spaces into a single space
+	// Collapse runs of whitespace
 	title = regexp.MustCompile(`\s+`).ReplaceAllString(title, " ")
 
-	return title
+	// Ensure dashes have a single space on each side
+	title = regexp.MustCompile(`\s*-\s*`).ReplaceAllString(title, " - ")
+
+	// Trim any trailing or leading whitespace introduced by replacements
+	return strings.TrimSpace(title)
 }

--- a/nombra_test.go
+++ b/nombra_test.go
@@ -1,0 +1,18 @@
+package main
+
+import "testing"
+
+func TestCleanTitle(t *testing.T) {
+	cases := map[string]string{
+		" \"2024.03.31 -John Doe-Title\" \n": "2024.03.31 - John Doe - Title",
+		"FooBar":                             "Foo Bar",
+		"  Something-Else  ":                 "Something - Else",
+	}
+
+	for in, want := range cases {
+		got := cleanTitle(in)
+		if got != want {
+			t.Errorf("cleanTitle(%q) = %q; want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- normalize spacing around hyphens and trim whitespace in `cleanTitle`
- add unit test for `cleanTitle`

## Testing
- `go test ./...` *(fails: `proxy.golang.org` blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688738758c508332b28cd256c965a033