### PR TITLE
Implement optional model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ While nombra automatically opts for OCR when needed, you can also force it:
 ./nombra myfile.pdf --verbose
 ```
 
+### Selecting an OpenAI model
+By default, Nombra uses `gpt-3.5-turbo` for title generation. You can choose a
+different model with the `--model` flag:
+```sh
+./nombra myfile.pdf --model gpt-4-turbo
+```
+
 ## Contributing
 Pull requests and issues are welcome! Please follow these guidelines:
 - Report bugs and feature requests via GitHub issues.

--- a/nombra.go
+++ b/nombra.go
@@ -99,7 +99,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	rootCmd.PersistentFlags().BoolVarP(&ocr, "ocr", "o", false, "Force OCR text extraction")
 	rootCmd.PersistentFlags().StringVarP(&model, "model", "m", openai.GPT3Dot5Turbo, "OpenAI model to use")
-	rootCmd.Flags().IntVarP(&maxContentLength, "max-content-length", "m", 3000, "Maximum content length for processing")
+	rootCmd.Flags().IntVarP(&maxContentLength, "max-content-length", "l", 3000, "Maximum content length for processing")
 	rootCmd.Flags().IntVarP(&minContentLength, "min-content-length", "n", 10, "Minimum content length required for processing")
 	rootCmd.Flags().StringVarP(&apiKey, "key", "k", "", "OpenAI API key (default: $OPENAI_API_KEY)")
 


### PR DESCRIPTION
## Summary
- add example usage for selecting a model via the new `--model` flag
- mention default `gpt-3.5-turbo` model in help and README

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6887385aece483328dba0e3877570922