### PR TITLE
Implement optional model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ While nombra automatically opts for OCR when needed, you can also force it:
 ./nombra myfile.pdf --verbose
 ```
 
+### Selecting an OpenAI model
+By default, Nombra uses `gpt-3.5-turbo` for title generation. You can choose a
+different model with the `--model` flag:
+```sh
+./nombra myfile.pdf --model gpt-4-turbo
+```
+
 ## Contributing
 Pull requests and issues are welcome! Please follow these guidelines:
 - Report bugs and feature requests via GitHub issues.

--- a/nombra.go
+++ b/nombra.go
@@ -41,6 +41,7 @@ var (
 	maxContentLength = 3000
 	minContentLength = 10
 	ocr              bool
+	model            string
 )
 
 // main initializes and executes the CLI command for generating a title for a PDF file.
@@ -50,10 +51,11 @@ func main() {
 	var apiKey string
 
 	rootCmd := &cobra.Command{
-		Use:   "nombra [PDF file]",
-		Short: "Generate titles for PDF documents using AI",
-		Long:  "A CLI tool that analyzes PDF content and generates appropriate titles using OpenAI's API",
-		Args:  cobra.ExactArgs(1),
+		Use:     "nombra [PDF file]",
+		Short:   "Generate titles for PDF documents using AI",
+		Long:    "A CLI tool that analyzes PDF content and generates appropriate titles using OpenAI's API",
+		Example: "nombra myfile.pdf\n  nombra myfile.pdf --model gpt-4-turbo",
+		Args:    cobra.ExactArgs(1),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			if apiKey == "" {
 				apiKey = os.Getenv("OPENAI_API_KEY")
@@ -75,7 +77,7 @@ func main() {
 				os.Exit(1)
 			}
 
-			title, err := generateOpenAITitle(textContent, apiKey)
+			title, err := generateOpenAITitle(textContent, apiKey, model)
 			if err != nil {
 				fmt.Printf("Title generation failed: %v\n", err)
 				os.Exit(1)
@@ -96,7 +98,8 @@ func main() {
 	// Configure flags
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	rootCmd.PersistentFlags().BoolVarP(&ocr, "ocr", "o", false, "Force OCR text extraction")
-	rootCmd.Flags().IntVarP(&maxContentLength, "max-content-length", "m", 3000, "Maximum content length for processing")
+	rootCmd.PersistentFlags().StringVarP(&model, "model", "m", openai.GPT3Dot5Turbo, "OpenAI model to use")
+	rootCmd.Flags().IntVarP(&maxContentLength, "max-content-length", "l", 3000, "Maximum content length for processing")
 	rootCmd.Flags().IntVarP(&minContentLength, "min-content-length", "n", 10, "Minimum content length required for processing")
 	rootCmd.Flags().StringVarP(&apiKey, "key", "k", "", "OpenAI API key (default: $OPENAI_API_KEY)")
 
@@ -329,7 +332,7 @@ func extractTextViaOCR(pdfPath string) (string, error) {
 // generateOpenAITitle sends the extracted PDF content to OpenAI's Chat Completion API
 // to generate an appropriate title based on specific formatting rules.
 // It then cleans the returned title to ensure proper formatting.
-func generateOpenAITitle(content, apiKey string) (string, error) {
+func generateOpenAITitle(content, apiKey, model string) (string, error) {
 	if content == "" {
 		return "", fmt.Errorf("empty content provided for title generation")
 	}
@@ -350,7 +353,7 @@ func generateOpenAITitle(content, apiKey string) (string, error) {
 	resp, err := client.CreateChatCompletion(
 		context.Background(),
 		openai.ChatCompletionRequest{
-			Model: openai.GPT3Dot5Turbo,
+			Model: model,
 			Messages: []openai.ChatCompletionMessage{
 				{
 					Role:    openai.ChatMessageRoleSystem,


### PR DESCRIPTION
## Summary
- add example usage for selecting a model via the new `--model` flag
- mention default `gpt-3.5-turbo` model in help and README
- resolve flag shorthand collision by assigning `-l` to `--max-content-length`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6887385aece483328dba0e3877570922