### PR TITLE
Add version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Nombra is a CLI tool that analyzes the content of PDF documents and generates me
 git clone https://github.com/YOUR_USERNAME/nombra.git
 cd nombra
 
-# Build the binary
-go build -o nombra
+# Build the binary with version information
+go build -ldflags="-X main.version=$(git rev-parse --short HEAD)" -o nombra
 ```
 
 ## Usage
@@ -54,6 +54,12 @@ While nombra automatically opts for OCR when needed, you can also force it:
 ### Verbose Mode
 ```sh
 ./nombra myfile.pdf --verbose
+```
+
+### Checking the Version
+Display the Git commit the binary was built from:
+```sh
+./nombra --version
 ```
 
 ### Adjusting Content Length

--- a/nombra.go
+++ b/nombra.go
@@ -38,6 +38,7 @@ const (
 
 var (
 	verbose          bool
+	version          = "dev"
 	maxContentLength = 3000
 	minContentLength = 10
 	ocr              bool
@@ -50,10 +51,11 @@ func main() {
 	var apiKey string
 
 	rootCmd := &cobra.Command{
-		Use:   "nombra [PDF file]",
-		Short: "Generate titles for PDF documents using AI",
-		Long:  "A CLI tool that analyzes PDF content and generates appropriate titles using OpenAI's API",
-		Args:  cobra.ExactArgs(1),
+		Use:     "nombra [PDF file]",
+		Short:   "Generate titles for PDF documents using AI",
+		Long:    "A CLI tool that analyzes PDF content and generates appropriate titles using OpenAI's API",
+		Version: version,
+		Args:    cobra.ExactArgs(1),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			if apiKey == "" {
 				apiKey = os.Getenv("OPENAI_API_KEY")


### PR DESCRIPTION
## Summary
- provide version at build time via `-X main.version` ldflag
- document version flag usage in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68875a847dfc8332a10bacfe87ac68f1