### PR TITLE
Fix Go workflow version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version-file: go.mod
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
## Summary
- use the Go version declared in `go.mod` when running CI

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68878195e5d883329946476495f313cc